### PR TITLE
Add link pointing to gnss-sdr.conf file in GNSS-SDR repository

### DIFF
--- a/_posts/2016-06-23-rtl2832U.md
+++ b/_posts/2016-06-23-rtl2832U.md
@@ -48,7 +48,7 @@ The compilation of the RTL2832U support in GNSS-SDR is optional and it requires 
 
 ## Configuring GNSS-SDR for GPS L1 real-time operation
 
-In order to use a compatible USB DVB-T device it is necessary to select the Osmosdr_Signal_Source in the GNSS-SDR configuration file (gnss-sdr.conf) as the SignalSource block. In addition, the following parameters should be configured:
+In order to use a compatible USB DVB-T device it is necessary to select the Osmosdr_Signal_Source in the GNSS-SDR configuration file ([gnss-sdr.conf](https://github.com/gnss-sdr/gnss-sdr/blob/master/conf/gnss-sdr.conf)) as the SignalSource block. In addition, the following parameters should be configured:
 
  * the baseband sampling frequency,
  * the RF center frequency,


### PR DESCRIPTION
I think it would be very convenient to have a link pointing to the [gnss-sdr.conf](https://github.com/gnss-sdr/gnss-sdr/blob/master/conf/gnss-sdr.conf) file in the GNSS-SDR repository.