### PR TITLE
Update in website documentation in "Build and install" section regarding Install dependencies using package for Ubuntu 18.04 and above.

### DIFF
--- a/_quick-start/03-build-and-install.md
+++ b/_quick-start/03-build-and-install.md
@@ -117,6 +117,19 @@ $ sudo apt-get install build-essential cmake git libboost-dev \
    libpugixml-dev libpcap-dev libgtest-dev googletest
 ```
 
+If you are using Ubuntu 18.04 or above, this can be done by copying and pasting the following line in a terminal:
+
+```bash
+$ sudo apt-get install build-essential cmake git libboost-dev \
+   libboost-date-time-dev libboost-system-dev libboost-filesystem-dev \
+   libboost-thread-dev libboost-chrono-dev libboost-serialization-dev \
+   libboost-program-options-dev libboost-test-dev liblog4cpp5-dev \
+   libuhd-dev gnuradio-dev gr-osmosdr libblas-dev liblapack-dev \
+   libarmadillo-dev libgflags-dev libgoogle-glog-dev libhdf5-dev \
+   libgnutls28-dev libmatio-dev python-mako python-six \
+   libpugixml-dev libpcap-dev libgtest-dev googletest
+```
+
 
 **Note for Ubuntu 14.04 LTS users:**
 you will need to build from source and install GNU Radio manually, as explained below, since GNSS-SDR requires gnuradio-dev >= 3.7.3, and Ubuntu 14.04 came with 3.7.2. Install all the packages above BUT EXCEPT ```libuhd-dev```, ```gnuradio-dev``` and ```gr-osmosdr``` (and remove them if they are already installed in your machine), and install those dependencies using PyBOMBS, as explained below.


### PR DESCRIPTION
As Ubuntu 18.04 and above requires particular version name of package i.e “libgnutls28-dev” instead of “libgnutls-openssl-dev” for installing GNU TLS library otherwise it shows error, I have added extra section in “03-build-and-install.md” file for installing dependencies using packages for “Ubuntu 18.04 and above” in “Build and Install” in documentation on website.

Regards,
Andrew Kamble
:+1::tada: Hello, and thanks for contributing to the [GNSS-SDR Website](https://gnss-sdr.org)! :tada::+1:

Before submitting your pull request, please make sure the following is done:
 1. You undertake the [Contributor Covenant Code of Conduct](https://github.com/gnss-sdr/geniuss-place/blob/master/CODE_OF_CONDUCT.md).
 2. You have read the [Contributing Guidelines](https://github.com/gnss-sdr/geniuss-place/blob/master/CONTRIBUTING.md).
 3. You have forked the [geniuss-place repository](https://github.com/gnss-sdr/geniuss-place) and have created your branch from `master`.
 4. You have run `bundle exec jekyll serve -w --config _config.yml,_config.dev.yml` in your own machine and have made sure that the changes look nice pointing your browser to http://127.0.0.1:4000/
 5. Please include a description of your changes here.

**Please feel free to delete the above text once you have read it and you want to go on with your pull request.**
