### PR TITLE
File_Signal_Source has no attribute .freq  [ref](https://gnss-sdr.org…

### DIFF
--- a/_posts/2019-01-15-monitoring-software-receiver-internal-status.md
+++ b/_posts/2019-01-15-monitoring-software-receiver-internal-status.md
@@ -472,7 +472,6 @@ SignalSource.implementation=File_Signal_Source
 SignalSource.filename=/home/your-username/work/data/2013_04_04_GNSS_SIGNAL_at_CTTC_SPAIN.dat
 SignalSource.item_type=ishort
 SignalSource.sampling_frequency=4000000
-SignalSource.freq=1575420000
 SignalSource.samples=0
 
 ;######### SIGNAL_CONDITIONER CONFIG ############

--- a/_quick-start/04-my-first-position-fix.md
+++ b/_quick-start/04-my-first-position-fix.md
@@ -84,7 +84,6 @@ SignalSource.implementation=File_Signal_Source
 SignalSource.filename=/home/your-username/work/data/2013_04_04_GNSS_SIGNAL_at_CTTC_SPAIN.dat
 SignalSource.item_type=ishort
 SignalSource.sampling_frequency=4000000
-SignalSource.freq=1575420000
 SignalSource.samples=0
 
 ;######### SIGNAL_CONDITIONER CONFIG ############


### PR DESCRIPTION
File_Signal_Source has no attribute .freq  [ref](https://gnss-sdr.org/docs/sp-blocks/signal-source/#implementation-file_signal_source)


I think I have seen that mentioned somewhere else where to compensate for frequency effects or so. If I did not overlook something and this parameter does nothing I would remove it for clarification (I checked the file_signal_source.h + .cc).
